### PR TITLE
read db using raw github link with python

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains:
 - [notebooks/otim-fit.ipynb](notebooks/otim-fit.iypnb): fits of a linear relationships in log-space between the hydraulic conductivity and the applied tension
 - [notebooks/otim-eda.iypnb](notebooks/otimdb-eda.ipynb): exploratory data analysis (EDA) of the database
 - [notebooks/meta-analysis.ipynb](notebooks/meta-analysis.ipynb): calculation of effect sizes for specific factors on saturated and near-saturated hydraulic conductivity
-- [interactive EDA](https://BenjMy.github.io/otim-db/eda-plotly.html): a tool to interactively explore the database (beta)
+- [interactive EDA](https://climasoma.github.io/otim-db/eda-plotly.html): a tool to interactively explore the database (beta)
 
 ## Citation
 Refer to this citation if you make use of the database:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains:
 - [notebooks/otim-fit.ipynb](notebooks/otim-fit.iypnb): fits of a linear relationships in log-space between the hydraulic conductivity and the applied tension
 - [notebooks/otim-eda.iypnb](notebooks/otimdb-eda.ipynb): exploratory data analysis (EDA) of the database
 - [notebooks/meta-analysis.ipynb](notebooks/meta-analysis.ipynb): calculation of effect sizes for specific factors on saturated and near-saturated hydraulic conductivity
-- [interactive EDA](https://climasoma.github.io/otim-db/eda-plotly.html): a tool to interactively explore the database (beta)
+- [interactive EDA](eda-plotly.html): a tool to interactively explore the database (beta)
 
 ## Citation
 Refer to this citation if you make use of the database:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains:
 - [notebooks/otim-fit.ipynb](notebooks/otim-fit.iypnb): fits of a linear relationships in log-space between the hydraulic conductivity and the applied tension
 - [notebooks/otim-eda.iypnb](notebooks/otimdb-eda.ipynb): exploratory data analysis (EDA) of the database
 - [notebooks/meta-analysis.ipynb](notebooks/meta-analysis.ipynb): calculation of effect sizes for specific factors on saturated and near-saturated hydraulic conductivity
-- [interactive EDA](eda-plotly.html): a tool to interactively explore the database (beta)
+- [interactive EDA](https://BenjMy.github.io/otim-db/eda-plotly.html): a tool to interactively explore the database (beta)
 
 ## Citation
 Refer to this citation if you make use of the database:

--- a/eda-plotly.html
+++ b/eda-plotly.html
@@ -52,7 +52,6 @@
        
 
     <script>
-	Access-Control-Allow-Origin: *
         let status = document.getElementById('status')
 
         // load pyodide itself and related packages
@@ -75,14 +74,18 @@ import numpy as np
 figBar = ''
 figMap = ''
 figLine = ''
+`)
 
-# load database
-#db = 'https://drive.google.com/uc?id=1hE8UMN4L0Gku45mjAlxarOSVlWbSDuzH'
-#db = 'http://localhost:8000/data/dfotim.csv'
-db = 'https://github.com/climasoma/otim-db/raw/main/data/dfotim.csv'
-response = await fetch(db)
-js_buffer = await response.arrayBuffer()
-dfm = pd.read_csv(BytesIO(js_buffer.to_py()))
+//load database
+// db = 'https://drive.google.com/uc?id=1hE8UMN4L0Gku45mjAlxarOSVlWbSDuzH'
+// db = 'http://localhost:8000/data/dfotim.csv'
+// db = 'http://localhost:8000/data/dfotim.csv'
+db = 'https://raw.githubusercontent.com/climasoma/otim-db/main/data/dfotim.csv'
+
+            await pyodide.runPythonAsync(`
+
+data = pyodide.open_url(db)
+dfm = pd.read_csv(data)
 
 # build the dictionnaries
 dicfeat = {}

--- a/eda-plotly.html
+++ b/eda-plotly.html
@@ -80,10 +80,11 @@ figLine = ''
 // db = 'https://drive.google.com/uc?id=1hE8UMN4L0Gku45mjAlxarOSVlWbSDuzH'
 // db = 'http://localhost:8000/data/dfotim.csv'
 // db = 'http://localhost:8000/data/dfotim.csv'
-db = 'https://raw.githubusercontent.com/climasoma/otim-db/main/data/dfotim.csv'
+
 
             await pyodide.runPythonAsync(`
 
+db = 'https://raw.githubusercontent.com/climasoma/otim-db/main/data/dfotim.csv'
 data = pyodide.open_url(db)
 dfm = pd.read_csv(data)
 

--- a/eda-plotly.html
+++ b/eda-plotly.html
@@ -52,6 +52,7 @@
        
 
     <script>
+	Access-Control-Allow-Origin: *
         let status = document.getElementById('status')
 
         // load pyodide itself and related packages


### PR DESCRIPTION
Before the changes, the db was read using JS and a **CORS issue** prevented accessing the data. 

I propose the following tweaks: 
- change the link to the csv from  'github.com'  to 'raw.githubusercontent.com' 
- read the db using:
   ```
  data = pyodide.open_url(db)
  dfm = pd.read_csv(data)
   ```

I successfully tested it locally on Chrome and Firefox. 
I let you review the changes.

Thanks for your awesome work. 